### PR TITLE
Uv tool install (fixes #3)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include midap/**/*.json

--- a/midap/imcut/interactive_cutout.py
+++ b/midap/imcut/interactive_cutout.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import matplotlib.pyplot as plt
 from matplotlib.widgets import RectangleSelector
+from matplotlib.backend_bases import MouseButton
 
 
 from .base_cutout import CutoutImage
@@ -67,7 +68,7 @@ class InteractiveCutout(CutoutImage):
             self.ax[0],
             self.line_select_callback,
             useblit=True,
-            button=[1],
+            button=MouseButton.LEFT,
             minspanx=5,
             minspany=5,
             spancoords="pixels",

--- a/midap/imcut/semiautomated_cutout.py
+++ b/midap/imcut/semiautomated_cutout.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.widgets import RectangleSelector
+from matplotlib.backend_bases import MouseButton
 from scipy.signal import find_peaks_cwt
 from skimage.registration import phase_cross_correlation
 
@@ -175,9 +176,8 @@ class SemiAutomatedCutout(CutoutImage):
         rs = RectangleSelector(
             self.ax[0],
             self.line_select_callback,
-            drawtype="box",
             useblit=True,
-            button=[1],
+            button=MouseButton.LEFT,
             minspanx=5,
             minspany=5,
             spancoords="pixels",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     {name = "Fluri Janis",        email = "janis.fluri@id.ethz.ch"},
 ]
 keywords = ["Segmentation", "Tracking", "Biology"]
-requires-python = ">=3.9, <4"
+requires-python = "==3.10.*"
 
 # install_requires is provided dynamically by setup.py so that the Euler cluster
 # install (MIDAP_INSTALL_VERSION=euler) can substitute its own pinned set.


### PR DESCRIPTION
fixes #3 

fda3541fab2d3a32760d0c5e4b79ae409c3fbd23 makes sure that data JSON files (such as download_info.json) is included when installing via uv (not sure exactly why this is needed, tool.setuptools.include-package-data = true should suffice

ba375c86f94db9eed8b89f2828c41abb8715038a fixed deprecated arguments to RectangleSelector. draw type = 'box' is the default (and I think only) option.

112d6cd408b0b59c6a0782c95545dfc1921e6c72 specifies the exact python version for midap (== 3.10.*)

6d661d420961941ddd83e7351e055684784353b2 fixes another deprecated argument in RectangleSelector