### PR TITLE
Semi automated cutout with selection of channels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include midap/**/*.json

--- a/midap/apps/cut_chamber.py
+++ b/midap/apps/cut_chamber.py
@@ -4,6 +4,7 @@ import os
 # import to get all subclasses
 from midap.imcut import *
 from midap.imcut import base_cutout
+from midap.utils import get_inheritors
 
 from typing import Optional, Union, Iterable
 
@@ -27,7 +28,7 @@ def main(
     """
     # get the right subclass
     class_instance = None
-    for subclass in base_cutout.CutoutImage.__subclasses__():
+    for subclass in get_inheritors(base_cutout.CutoutImage):
         if subclass.__name__ == cutout_class:
             class_instance = subclass
 

--- a/midap/imcut/semiautomated_cutout.py
+++ b/midap/imcut/semiautomated_cutout.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.widgets import RectangleSelector
+from matplotlib.backend_bases import MouseButton
 from scipy.signal import find_peaks_cwt
 from skimage.registration import phase_cross_correlation
 
@@ -175,9 +176,8 @@ class SemiAutomatedCutout(CutoutImage):
         rs = RectangleSelector(
             self.ax[0],
             self.line_select_callback,
-            drawtype="box",
             useblit=True,
-            button=[1],
+            button=MouseButton.LEFT,
             minspanx=5,
             minspany=5,
             spancoords="pixels",

--- a/midap/imcut/semiautomated_cutout_select.py
+++ b/midap/imcut/semiautomated_cutout_select.py
@@ -1,0 +1,76 @@
+import matplotlib.pyplot as plt
+
+from midap.utils import GUI_selector
+
+from .semiautomated_cutout import SemiAutomatedCutout
+
+
+def _chunked(lst, n):
+    """Yield successive n-sized chunks from lst. Source - https://stackoverflow.com/a/312464"""
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]
+
+
+class SemiAutomatedCutoutSelect(SemiAutomatedCutout):
+    """
+    A class that performs the image cutout for the different channels in interactive mode with an additional step to select the chambers to include in the cutout
+    """
+
+    supported_setups = ["Mother_Machine"]
+
+    def cut_corners(self, img):
+        """
+        Given a single aligned image as array, it defines the corners that are used to cut out all images
+        Additionally, it allows the user to select which chambers to include in the cutout
+        :param img: Image to cut as array
+        :returns: The corners of the cutout as tuple (left_x, right_x, lower_y, upper_y), where full range of the
+                  image, i.e. the limits of the corners, are given by the total number of pixels.
+        """
+
+        # interactive cutout of chambers
+        corners = self.interactive_cutout(img)
+        self.corners_cut = tuple([int(i) for i in corners])
+
+        # check that offsets are defined, for completeness sake
+        if self.offsets is None:
+            raise ValueError("Offsets must be defined for SemiAutomatedCutoutSelect!")
+
+        # select the chambers to include in the cutout
+        self.logger.info("Selecting Chambers to include")
+        self.logger.info(f"All offset idx: {list(range(len(self.offsets)))}")
+        selected_offsets_idx = []
+        chunk_size = 12
+        n_chunks = len(self.offsets) // chunk_size + 1
+        i_chunk = 0
+        for batch in _chunked(list(enumerate(self.offsets)), chunk_size):
+            figures = []
+            indices = []
+            for i, offset in batch:
+                base_corners = (
+                    self.corners_cut[0] + offset,
+                    self.corners_cut[1] + offset,
+                    self.corners_cut[2],
+                    self.corners_cut[3],
+                )
+
+                # perform the cutout of the first image
+                chamber_img = self.do_cutout(img, base_corners)
+                fig, ax = plt.subplots(figsize=(1, 2))
+                ax.imshow(chamber_img)
+                ax.set_xticks([])
+                ax.set_yticks([])
+                ax.set_title(str(i))
+                figures.append(fig)
+                indices.append(i)
+
+            marked = GUI_selector(
+                figures,
+                labels=indices,
+                title=f"Select chambers {i_chunk}/{n_chunks}",
+                multiselect=True,
+                marked=indices,
+            )
+            selected_offsets_idx.extend(marked)
+            i_chunk += 1
+        self.logger.info(f"Selected offset idx: {selected_offsets_idx}")
+        self.offsets = [self.offsets[i] for i in selected_offsets_idx]

--- a/midap/imcut/semiautomated_cutout_select.py
+++ b/midap/imcut/semiautomated_cutout_select.py
@@ -39,9 +39,12 @@ class SemiAutomatedCutoutSelect(SemiAutomatedCutout):
         self.logger.info("Selecting Chambers to include")
         self.logger.info(f"All offset idx: {list(range(len(self.offsets)))}")
         selected_offsets_idx = []
+
         chunk_size = 12
-        n_chunks = len(self.offsets) // chunk_size + 1
-        i_chunk = 0
+        n_whole_chunks = len(self.offsets) // chunk_size
+        n_chunks = n_whole_chunks + (1 if len(self.offsets) % chunk_size > 0 else 0)
+        i_chunk = 1
+
         for batch in _chunked(list(enumerate(self.offsets)), chunk_size):
             figures = []
             indices = []

--- a/midap/utils.py
+++ b/midap/utils.py
@@ -154,8 +154,13 @@ def GUI_selector(
     if len(figures) != len(labels):
         raise ValueError("Number of figures does not match number of labels!")
 
+    # if no marked is given, we mark the first one
     if marked is None:
         marked = [labels[0]]
+    
+    # if marked is the same as labels (i.e. all are marked), we make a copy of the list to avoid modifying the original list when we unmark some of the labels
+    if marked is labels:
+        marked = labels.copy()
 
     # get the number of cols for the layout
     num_cols = int(np.ceil(np.sqrt(len(labels))))

--- a/midap/utils.py
+++ b/midap/utils.py
@@ -6,7 +6,6 @@ import sys
 import threading
 from typing import Collection, Union, Tuple, Optional
 
-import PIL
 import midap.apps.PySimpleGUI as sg
 import matplotlib.pyplot as plt
 import numpy as np
@@ -89,20 +88,20 @@ def convert_to_bytes(
     """
 
     if isinstance(file_or_bytes, str):
-        img = PIL.Image.open(file_or_bytes)
+        img = Image.open(file_or_bytes)
     else:
         try:
-            img = PIL.Image.open(io.BytesIO(base64.b64decode(file_or_bytes)))
-        except Exception as e:
+            img = Image.open(io.BytesIO(base64.b64decode(file_or_bytes)))
+        except Exception as _:
             dataBytesIO = io.BytesIO(file_or_bytes)
-            img = PIL.Image.open(dataBytesIO)
+            img = Image.open(dataBytesIO)
 
     cur_width, cur_height = img.size
     if resize:
         new_width, new_height = resize
         scale = min(new_height / cur_height, new_width / cur_width)
         img = img.resize(
-            (int(cur_width * scale), int(cur_height * scale)), PIL.Image.ANTIALIAS
+            (int(cur_width * scale), int(cur_height * scale)), Image.Resampling.LANCZOS
         )
     with io.BytesIO() as bio:
         img.save(bio, format="GIF")

--- a/midap/utils.py
+++ b/midap/utils.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 import threading
-from typing import Collection, Union, Tuple, Optional
+from typing import Union, Tuple, Optional, Any
 
 import midap.apps.PySimpleGUI as sg
 import matplotlib.pyplot as plt
@@ -109,21 +109,53 @@ def convert_to_bytes(
         return bio.getvalue()
 
 
+def _gui_selector_button(
+    buf: bytes, label: Any, marked: bool = False
+) -> sg.Button:
+    """Creates a button for the GUI selector with the given image and label, and marks it if specified
+    :param buf: The image to display on the button as bytes
+    :param label: The key for the button
+    :param marked: Whether the button should be marked as selected
+    :return: The created button
+    """
+    if marked:
+        button_color = ("black", "yellow")
+    else:
+        button_color = (sg.theme_background_color(), sg.theme_background_color())
+    return sg.Button(
+        "",
+        image_data=buf,
+        button_color=button_color,
+        border_width=5,
+        key=label,
+    )
+
+
 def GUI_selector(
-    figures: Collection[plt.Figure], labels: Collection[str], title="", close_figs=True
-):
+    figures: list[plt.Figure],
+    labels: list[Any],
+    title: str = "",
+    close_figs: bool = True,
+    multiselect: bool = False,
+    marked: list[Any] | None = None,
+) -> Union[Any, list[Any]]:
     """
     Starts up a GUI selector for imgs and labels
     :param figures: A list of figures that will presented in the GUI as buttons that the user can select
     :param labels: A list of labels corresponding to the input images
     :param title: Title for the GUI
     :param close_figs: Close all figures after the GUI has extracted the data
-    :return: The label that the user selected by clicking on the corresponding image
+    :param multiselect: If True, allow multiple selections
+    :param marked: The label(s) that should be marked as selected initially
+    :return: The label(s) that the user selected by clicking on the corresponding image
     """
 
     # check
     if len(figures) != len(labels):
-        raise ValueError("Number of figures does not math number of labels!")
+        raise ValueError("Number of figures does not match number of labels!")
+
+    if marked is None:
+        marked = [labels[0]]
 
     # get the number of cols for the layout
     num_cols = int(np.ceil(np.sqrt(len(labels))))
@@ -132,7 +164,7 @@ def GUI_selector(
     buffers = []
     buttons = []
     new_line = []
-    for i, (fig, label) in enumerate(zip(figures, labels)):
+    for fig, label in zip(figures, labels):
         # figure to buffer
         buf = io.BytesIO()
         fig.savefig(buf, format="png")
@@ -140,30 +172,7 @@ def GUI_selector(
         buf = convert_to_bytes(buf.read())
         buffers.append(buf)
         # the first button starts as selected
-        if i == 0:
-            new_line.append(
-                sg.Button(
-                    "",
-                    image_data=buf,
-                    button_color=("black", "yellow"),
-                    border_width=5,
-                    key=label,
-                )
-            )
-            marked = label
-        else:
-            new_line.append(
-                sg.Button(
-                    "",
-                    image_data=buf,
-                    button_color=(
-                        sg.theme_background_color(),
-                        sg.theme_background_color(),
-                    ),
-                    border_width=5,
-                    key=label,
-                )
-            )
+        new_line.append(_gui_selector_button(buf, label, marked=label in marked))
         if len(new_line) == num_cols:
             buttons.append(new_line)
             new_line = []
@@ -216,23 +225,29 @@ def GUI_selector(
     # Event Loop
     while True:
         # Read event
-        event, values = window.read()
+        event, _ = window.read()
         # break if we have one of these
         if event in (sg.WIN_CLOSED, "Exit", "Cancel", "OK"):
             break
 
         # get the last event
-        for i, l in enumerate(labels):
+        for label in labels:
             # if the last event was an image button click, mark it
-            if event == l:
-                marked = l
+            if event == label:
+                if multiselect:
+                    if label in marked:
+                        marked.remove(label)
+                    else:
+                        marked.append(label)
+                else:
+                    marked = [label]
                 break
-        # maked button is highlighted
-        for l in labels:
-            if marked == l:
-                window[l].update(button_color=("black", "yellow"))
+        # marked button is highlighted
+        for label in labels:
+            if label in marked:
+                window[label].update(button_color=("black", "yellow"))
             else:
-                window[l].update(
+                window[label].update(
                     button_color=(
                         sg.theme_background_color(),
                         sg.theme_background_color(),
@@ -267,4 +282,7 @@ def GUI_selector(
     if event != "OK":
         raise InterruptedError("GUI was cancelled or unexpectedly closed, exiting...")
 
-    return marked
+    if multiselect:
+        return marked
+    else:
+        return marked[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     {name = "Fluri Janis",        email = "janis.fluri@id.ethz.ch"},
 ]
 keywords = ["Segmentation", "Tracking", "Biology"]
-requires-python = ">=3.9, <4"
+requires-python = "==3.10.*"
 
 # install_requires is provided dynamically by setup.py so that the Euler cluster
 # install (MIDAP_INSTALL_VERSION=euler) can substitute its own pinned set.


### PR DESCRIPTION
This pull request adds a new CutoutImage procedure. 

SemiAutomatedCutout is subclassed to add a 2nd step where detected channels can be deselected. This is useful when Images contain many empty chambers.

I thought this might be useful for other users as well.

~Depends /~ includes  #4 (but this could be changed)

- 47757fb478feaa12bec3adbacd1f96432a2f8fad does some minor cleanup in utils.py
- b7a615b8d5f941987e10aa2f120171b350515440 & d3a7dd7a13cf0aba5ae6cb492e09f474214e45fe extends GUI_selector to allow for multiselect, while keeping functionality intact (no changes in calls from other places needed.
- 6d2b11f274f13eca3e321cdde609c89cd7af5cbf implements the new subclass
- 160d5c6b0fbb3ae785afcc806fc55bf0c103682c fixes discovery of 'nested' subclasses for gui (using existing midap.utils.get_inheritors)